### PR TITLE
add wildcard support for zhp.pl

### DIFF
--- a/domains/zhp.pl.zone.js
+++ b/domains/zhp.pl.zone.js
@@ -7,6 +7,7 @@ var AZURE = NewDnsProvider('azuredns_main', 'AZURE_DNS');
 D('zhp.pl', REG_NONE, DnsProvider(AZURE), DefaultTTL(3600),
     A('@', '51.75.54.175'),
     Ms365_Root('zhp.pl'),
+    A('*', '51.75.54.175'),
     CNAME('selector1._domainkey', 'selector1-zhp-pl._domainkey.gkzhp.onmicrosoft.com.'),
     CNAME('selector2._domainkey', 'selector2-zhp-pl._domainkey.gkzhp.onmicrosoft.com.')
 );


### PR DESCRIPTION
Wrzucam pull requesta na prośbę @dkoryto.

Nie jestem pewien, czy chcemy zrobić to w ten sposób. 
Osobiście wolałbym ustawiać rekordy pod redirecty bezpośrednio. W przypadku chociażby usunięcia jakieś starej domeny, ściągamy wszystkie request z niej na naszego pleska.