### PR TITLE
Use WIX-specific settings for Polkowice

### DIFF
--- a/domains/zhp.pl.d/dolnoslaska.js
+++ b/domains/zhp.pl.d/dolnoslaska.js
@@ -4,5 +4,5 @@ D_EXTEND('zhp.pl',
          CNAME('www.polkowice', 'www118.wixdns.net.'),
          CNAME('de.polkowice', 'www118.wixdns.net.'),
          CNAME('en.polkowice', 'www118.wixdns.net.'),
-         CNAME('pl.polkowice', 'www118.wixdns.net.'),
+         CNAME('pl.polkowice', 'www118.wixdns.net.')
 );

--- a/domains/zhp.pl.d/dolnoslaska.js
+++ b/domains/zhp.pl.d/dolnoslaska.js
@@ -1,3 +1,8 @@
 D_EXTEND('zhp.pl',
-         Delegation_CNAME('polkowice', 'www118.wixdns.net.') // MS365-7672
+         // WIX set-up for Polkowice (MS365-7672)
+         CNAME('polkowice', 'www118.wixdns.net.'),
+         CNAME('www.polkowice', 'www118.wixdns.net.'),
+         CNAME('de.polkowice', 'www118.wixdns.net.'),
+         CNAME('en.polkowice', 'www118.wixdns.net.'),
+         CNAME('pl.polkowice', 'www118.wixdns.net.'),
 );


### PR DESCRIPTION
WIX requires both main domain and www to point directly to their domain to accept the domain. 
Also 3 other domains added for language-specific pages