### PR TITLE
Przenosimy kwidzyn na netmark

### DIFF
--- a/domains/zhp.pl.d/gdanska.js
+++ b/domains/zhp.pl.d/gdanska.js
@@ -11,7 +11,7 @@ D_EXTEND('zhp.pl',
     Delegation_NS('starogard', ['ns108.ovh.net.', 'dns108.ovh.net.']), // MS365-7432
     Delegation_NS('czarnawoda', ['ns7.webd.pl.', 'ns5.webd.pl.']),
     Delegation_NS('kartuzy', ['ns1.hostbox.pl.', 'ns2.hostbox.pl.']),
-    Delegation_NS('kwidzyn', ogicom),
+    Delegation_NS('kwidzyn', ['ns1.netmark.pl.', 'ns2.netmark.pl.', 'ns3.netmark.pl.', 'ns4.netmark.pl.']),
     Delegation_NS('lebork', ['dns11.linuxpl.com.', 'ns11.linuxpl.com.']),
     Delegation_NS('miastko', ['ns7.webd.pl.', 'ns5.webd.pl.']),
     Delegation_NS('puck', ogicom),


### PR DESCRIPTION
Obecnie kwidzyn.zhp.pl  ma na ogicomie przekierowanie w JS na kwidzynzhp.pl (hostowany na netmark)
Od teraz kwidzyn.zhp.pl będzie kierować do netmarka, więc nie będzie przekierowania

Poczta w domenie kwidzyna nie jest obecnie skonfigurowana