### PR TITLE
Update opolska.js

### DIFF
--- a/domains/zhp.pl.d/opolska.js
+++ b/domains/zhp.pl.d/opolska.js
@@ -15,6 +15,8 @@ D_EXTEND('zhp.pl',
   Delegation_NS('opole', ['a.eco.atman.pl.', 'b.eco.atman.pl.']),
   Delegation_NS('praszka', ['a.eco.atman.pl.', 'b.eco.atman.pl.']),
   
+  Delegation_NS('harcezastepow', ['a.eco.atman.pl.', 'b.eco.atman.pl.']),       
+         
   TXT('praszka', 'YCt6GUiBSQdODPJJJ9SnkA'),
 
   CNAME('opolemiasto', 'opole.zhp.pl.')


### PR DESCRIPTION
Do delegacji w liście Chorągwi Opolskiej dodałem subdomenę harcezastepow.zhp.pl. Trwa przejście domenowe z .pl na subdomenę .zhp.pl. Proszę o akceptację :)