### PR TITLE
Zmiany w Lubuskiej

### DIFF
--- a/domains/zhp.pl.d/lubuska.js
+++ b/domains/zhp.pl.d/lubuska.js
@@ -25,8 +25,6 @@ D_EXTEND('zhp.pl',
 
     // Delegacja domeny hufca Sulęcin
     Ms365_Subdomain('sulecin','zhp.pl'),
-    CNAME('www.sulecin', 'zhpsul.jimdofree.com.'), // MS365-10341
-    A('sulecin', '51.75.54.175'), // MS365-10341
 
     //Delegacja domeny hufca Szprotawa
     Delegation_NS('szprotawa', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']),
@@ -36,6 +34,7 @@ D_EXTEND('zhp.pl',
 
     // Delegacja domeny hufca Żary
     Ms365_Subdomain('zary','zhp.pl'),
+    Delegation_A('zary', '5.252.231.83'), // MS365-11045
 
     //domena chorągwi
     Delegation_NS('lubuska', ['ns1.zenbox.pl.', 'ns2.zenbox.pl.'])


### PR DESCRIPTION
- Dodanie delegacji A dla Hufca Żary (MS365-11045)
- usunięcie delegacji dla Sulęcina