### PR TITLE
Przenoszę gdanska.zhp.pl do repozytorium

### DIFF
--- a/domains/redirects/redirectFiles/zhp.pl.json
+++ b/domains/redirects/redirectFiles/zhp.pl.json
@@ -5,5 +5,8 @@
     "csi": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
     "ksztalcenie": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
     "42zjazd": { "target": "https://gkzhp.sharepoint.com/SitePages/42.-Zjazd-ZHP(1).aspx", "method": 301 },
-    "wedrownicy.gdanska": { "target": "https://www.facebook.com/wedrownicygd", "method": 301 }
+
+    "wedrownicy.gdanska": { "target": "https://www.facebook.com/wedrownicygd", "method": 301 },
+    "nasiczne.gdanska": { "target": "http://nasiczne.bieszczady.pl/", "method": 302 },
+    "polkolonie.gdanska": { "target": "http://gdanska.zhp.pl/polkolonie/", "method": 301 }
 }

--- a/domains/redirects/redirectFiles/zhp.pl.json
+++ b/domains/redirects/redirectFiles/zhp.pl.json
@@ -4,5 +4,6 @@
     "poczta": { "target": "https://outlook.office.com", "method": 301 },
     "csi": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
     "ksztalcenie": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
-    "42zjazd": { "target": "https://gkzhp.sharepoint.com/SitePages/42.-Zjazd-ZHP(1).aspx", "method": 301 }
+    "42zjazd": { "target": "https://gkzhp.sharepoint.com/SitePages/42.-Zjazd-ZHP(1).aspx", "method": 301 },
+    "wedrownicy.gdanska": { "target": "https://www.facebook.com/wedrownicygd", "method": 301 }
 }

--- a/domains/zhp.pl.d/gdanska.js
+++ b/domains/zhp.pl.d/gdanska.js
@@ -29,4 +29,4 @@ D_EXTEND('zhp.pl',
     Delegation_NS('starekarpno', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']),
 
     // Przedsięwzięcia
-    Delegation_CNAME('jott.gdanska', 'gdanska.zhp.pl.'));
+    Delegation_CNAME('jott.gdanska.zhp.pl.', 'gdanska.zhp.pl.'));

--- a/domains/zhp.pl.d/gdanska.js
+++ b/domains/zhp.pl.d/gdanska.js
@@ -2,7 +2,8 @@ var ogicom = ['ns1.ogicom.pl.', 'ns2.ogicom.pl.', 'ns3.ogicom.pl.'];
 
 D_EXTEND('zhp.pl',
     // Chorągiew
-    Delegation_NS('gdanska', ogicom),
+    Delegation_A('gdanska', '93.157.100.67'),
+    Ms365_Subdomain('gdanska','zhp.pl'),
 
     // Hufce
     Delegation_NS('gdansk', ['dns1.thecamels.org.', 'dns2.thecamels.org.']),
@@ -25,4 +26,9 @@ D_EXTEND('zhp.pl',
     Ms365_Subdomain('slupsk','zhp.pl'),
 
     // Bazy
-    Delegation_NS('starekarpno', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']));
+    Delegation_NS('starekarpno', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']),
+    Delegation_CNAME('nasiczne', 'gdanska.zhp.pl.'),
+
+    // Przedsięwzięcia
+    Delegation_CNAME('polkolonie.gdanska', 'gdanska.zhp.pl.'),
+    Delegation_CNAME('jott.gdanska', 'gdanska.zhp.pl.'));

--- a/domains/zhp.pl.d/gdanska.js
+++ b/domains/zhp.pl.d/gdanska.js
@@ -29,5 +29,4 @@ D_EXTEND('zhp.pl',
     Delegation_NS('starekarpno', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']),
 
     // Przedsięwzięcia
-    Delegation_CNAME('polkolonie.gdanska', 'gdanska.zhp.pl.'),
     Delegation_CNAME('jott.gdanska', 'gdanska.zhp.pl.'));

--- a/domains/zhp.pl.d/gdanska.js
+++ b/domains/zhp.pl.d/gdanska.js
@@ -27,7 +27,6 @@ D_EXTEND('zhp.pl',
 
     // Bazy
     Delegation_NS('starekarpno', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']),
-    Delegation_CNAME('nasiczne', 'gdanska.zhp.pl.'),
 
     // Przedsięwzięcia
     Delegation_CNAME('polkolonie.gdanska', 'gdanska.zhp.pl.'),


### PR DESCRIPTION
Dotychczas Chorągiew Gdańska używała hostingu Cyberfolks
Chcemy jednak używać repozytorium, które jest wygodniejsze i zarządzane przez GK