### PR TITLE
Krok 0 migracji domeny Chorągwi Wielkopolskiej

### DIFF
--- a/domains/zhp.pl.d/wielkopolska.js
+++ b/domains/zhp.pl.d/wielkopolska.js
@@ -1,11 +1,11 @@
 D_EXTEND('zhp.pl',
     Delegation_A('wielkopolska', '2.57.138.154'), // MS365-13911
-        
+
     Delegation_NS('konin', ['ns1.kylos.pl.', 'ns2.kylos.pl.']),
     Delegation_NS('poznansrodmiescie', ['ns1.cal.pl.', 'ns2.cal.pl.']),
     Delegation_NS('poznanwilda', ['ns1.hostdmk.net.', 'ns2.hostdmk.net.']),
     Delegation_NS('siodemka', ['ns1.cal.pl.', 'ns2.cal.pl.']),
-   
+
     Delegation_NS('turek', ['ns1.kylos.pl.', 'ns2.kylos.pl.']),
     Delegation_NS('wolsztyn', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
     Delegation_NS('wrzesnia', ['ns1.interian.pl.', 'ns3.tomkii.net.']),
@@ -15,5 +15,7 @@ D_EXTEND('zhp.pl',
     Delegation_A('gniezno', '178.32.205.96'),
     Delegation_A('poznangrunwald', '94.23.27.27'),
 
-    Delegation_NS('wzlot', ['ns1.atthost.pl.', 'ns2.atthost.pl.'])
+    Delegation_NS('wzlot', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
+
+    Delegation_NS('wlkp', ['ns1.zenbox.pl', 'ns2.zenbox.pl'])
 );

--- a/domains/zhp.pl.d/wielkopolska.js
+++ b/domains/zhp.pl.d/wielkopolska.js
@@ -17,5 +17,5 @@ D_EXTEND('zhp.pl',
 
     Delegation_NS('wzlot', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
 
-    Delegation_NS('wlkp', ['ns1.zenbox.pl', 'ns2.zenbox.pl'])
+    Delegation_NS('wlkp', ['ns1.zenbox.pl.', 'ns2.zenbox.pl.'])
 );


### PR DESCRIPTION
Na prośbę Zespołu promocji Chorągwi Wielkopolskiej oraz Biura Chorągwii tworzymy subdomenę wlkp.zhp.pl, do której sukcesywnie będziemy migrować strony internetowe.