### PR TITLE
Przekierowanie deklaracja -> tipi

### DIFF
--- a/domains/redirects/redirectFiles/zhp.pl.json
+++ b/domains/redirects/redirectFiles/zhp.pl.json
@@ -5,6 +5,7 @@
     "csi": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
     "ksztalcenie": { "target": "https://gkzhp.sharepoint.com/SitePages/Centralna-Szko%C5%82a-Instruktorska.aspx", "method": 301 },
     "42zjazd": { "target": "https://gkzhp.sharepoint.com/SitePages/42.-Zjazd-ZHP(1).aspx", "method": 301 },
+    "deklaracja": { "target": "https://tipi.zhp.pl", "method": 301 },
 
     "wedrownicy.gdanska": { "target": "https://www.facebook.com/wedrownicygd", "method": 301 },
     "nasiczne.gdanska": { "target": "http://nasiczne.bieszczady.pl/", "method": 302 },


### PR DESCRIPTION
Przekierowanie zaproponowanę przez Kasię. Zmniejszy liczbę zgłoszeń o niedziałających deklaracjach (_informuje_, że teraz jest to w tipi)