### PR TITLE
Update DNS control to 3.17

### DIFF
--- a/.github/workflows/dns-push.yml
+++ b/.github/workflows/dns-push.yml
@@ -2,14 +2,12 @@ name: Deploy dns zone
 
 on:
   push:
-    branches:
-      - main
 
 jobs:
   dnscontrol:
     runs-on: ubuntu-latest
     container:
-      image: stackexchange/dnscontrol:v3.14.0
+      image: jauderho/dnscontrol:v3.17.0
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/dns-push.yml
+++ b/.github/workflows/dns-push.yml
@@ -2,6 +2,8 @@ name: Deploy dns zone
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   dnscontrol:


### PR DESCRIPTION
Currently, StackExchange has some issues with creating new docker images (they don't push them to the hub, CI issues). So I used less official image for new version of dnscontrol and it fixed