### PR TITLE
Usuwam nieużywane mailing.zhp.pl

### DIFF
--- a/domains/zhp.pl.zone.js
+++ b/domains/zhp.pl.zone.js
@@ -15,7 +15,6 @@ D('zhp.pl', ovhRegistrar, DnsProvider(cloudflareProvider), DefaultTTL(3600),
     // NS
     Delegation_NS('e-aos', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
     Delegation_NS('limev3', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
-    Delegation_NS('mailing', ['redir1.freshmail.pl.', 'redir2.freshmail.pl.']),
     Delegation_NS('pielgrzymka', ['dns.smarthost.pl.', 'dns2.smarthost.pl.', 'dns3.smarthost.pl.']), // ?
     Delegation_NS('rajdgranica', ['dns1.linuxpl.com.', 'dns2.linuxpl.com.', 'dns3.linuxpl.com.']), // cert error ale coś za nim jest
     Delegation_NS('westerplatte', ['ns1.hekko.net.pl.', 'ns2.hekko.net.pl.']), // cert error ale coś za nim stoi


### PR DESCRIPTION
Zgodnie z informacją od Martyny i Olgi - nie jest używane 