### PR TITLE
Migracja 'slawno' na hosting chorągwiany

### DIFF
--- a/domains/zhp.pl.d/zachodniopomorska.js
+++ b/domains/zhp.pl.d/zachodniopomorska.js
@@ -13,5 +13,4 @@ D_EXTEND('zhp.pl',
 	Delegation_NS('police', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
 	Delegation_NS('stargard', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
 	Delegation_NS('mysliborz', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
-	
-	Delegation_NS('slawno', ['ns1.ogicom.pl.', 'ns2.ogicom.pl.', 'ns3.ogicom.pl.']))
+	Delegation_NS('slawno', ['ns1.atthost.pl.', 'ns2.atthost.pl.']))


### PR DESCRIPTION
Wraz ze zmianą NS'a musimy dodać slawno.zhp.pl jako domenę do M365, aby przepiąć skrzynki pocztowe na tę domenę.

Poprosiłbym o kontakt, żeby to skoordynować przed mergem.