### PR TITLE
Zmiany w DNS hufca Turek

### DIFF
--- a/domains/zhp.pl.d/wielkopolska.js
+++ b/domains/zhp.pl.d/wielkopolska.js
@@ -7,6 +7,7 @@ D_EXTEND('zhp.pl',
     Delegation_NS('siodemka', ['ns1.cal.pl.', 'ns2.cal.pl.']),
 
     Delegation_A('turek', '195.162.24.10'),
+    Ms365_Subdomain('turek','zhp.pl'),
     Delegation_NS('wolsztyn', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
     Delegation_NS('wrzesnia', ['ns1.interian.pl.', 'ns3.tomkii.net.']),
     Delegation_NS('wschowa', ['ns1.atthost.pl.', 'ns2.atthost.pl.']), // MS365-9328

--- a/domains/zhp.pl.d/wielkopolska.js
+++ b/domains/zhp.pl.d/wielkopolska.js
@@ -6,7 +6,7 @@ D_EXTEND('zhp.pl',
     Delegation_NS('poznanwilda', ['ns1.hostdmk.net.', 'ns2.hostdmk.net.']),
     Delegation_NS('siodemka', ['ns1.cal.pl.', 'ns2.cal.pl.']),
 
-    Delegation_NS('turek', ['ns1.kylos.pl.', 'ns2.kylos.pl.']),
+    Delegation_A('turek', '195.162.24.10'),
     Delegation_NS('wolsztyn', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
     Delegation_NS('wrzesnia', ['ns1.interian.pl.', 'ns3.tomkii.net.']),
     Delegation_NS('wschowa', ['ns1.atthost.pl.', 'ns2.atthost.pl.']), // MS365-9328

--- a/domains/zhp.pl.d/wielkopolska.js
+++ b/domains/zhp.pl.d/wielkopolska.js
@@ -6,7 +6,7 @@ D_EXTEND('zhp.pl',
     Delegation_NS('poznanwilda', ['ns1.hostdmk.net.', 'ns2.hostdmk.net.']),
     Delegation_NS('siodemka', ['ns1.cal.pl.', 'ns2.cal.pl.']),
 
-    Delegation_A('turek', '195.162.24.10'),
+    Delegation_A('turek', '94.154.117.200'),
     Ms365_Subdomain('turek','zhp.pl'),
     Delegation_NS('wolsztyn', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
     Delegation_NS('wrzesnia', ['ns1.interian.pl.', 'ns3.tomkii.net.']),


### PR DESCRIPTION
Hufiec Turek chce podpiąć swoją domenę pod offica 365. Korzystają tylko ze strony, więc chce zamienić im delegację NS na delegację A i na repo użyć funkcji Ms365_Subdomain by odpowiednie rekordy ustawić.