### PR TITLE
Hufiec Moko - Weryfikacja Google

### DIFF
--- a/domains/zhp.pl.d/stoleczna.js
+++ b/domains/zhp.pl.d/stoleczna.js
@@ -6,6 +6,7 @@ D_EXTEND('zhp.pl',
     // Ogólnopolskie
     Delegation_A_WithCfProxy('arsenal', '109.95.159.40'),
     Ms365_Subdomain('arsenal', 'zhp.pl'),
+    CNAME('47649812.arsenal', 'google.com', TTL(3600)),
 
 
     // Hufce (hosting chorągwi)

--- a/domains/zhp.pl.d/stoleczna.js
+++ b/domains/zhp.pl.d/stoleczna.js
@@ -6,7 +6,7 @@ D_EXTEND('zhp.pl',
     // Ogólnopolskie
     Delegation_A_WithCfProxy('arsenal', '109.95.159.40'),
     Ms365_Subdomain('arsenal', 'zhp.pl'),
-    CNAME('47649812.arsenal', 'google.com', TTL(3600)),
+    CNAME('47649812.arsenal', 'google.com.', TTL(3600)),
 
 
     // Hufce (hosting chorągwi)


### PR DESCRIPTION
Tymczasowa weryfikacja Google dla `arsenal.zhp.pl`, chwila moment i usuwam (ok. tydzień).