### PR TITLE
Druga weryfikacja google dla `arsenal.zhp.pl`

### DIFF
--- a/domains/zhp.pl.d/stoleczna.js
+++ b/domains/zhp.pl.d/stoleczna.js
@@ -7,6 +7,7 @@ D_EXTEND('zhp.pl',
     Delegation_A_WithCfProxy('arsenal', '109.95.159.40'),
     Ms365_Subdomain('arsenal', 'zhp.pl'),
     CNAME('47649812.arsenal', 'google.com.', TTL(3600)),
+    TXT('arsenal', 'google-gws-recovery-domain-verification=47649812', TTL(3600)),
 
 
     // Hufce (hosting chorągwi)


### PR DESCRIPTION
Druga tymczasowa weryfikacja Google dla `arsenal.zhp.pl`, za ok. tydzień usunę.