### PR TITLE
Wsparcie dla wielu wpisów A oraz migracja Hufca Nowa Sól (MS365-35854)

### DIFF
--- a/domains/functions/delegation.js
+++ b/domains/functions/delegation.js
@@ -1,6 +1,8 @@
 function Delegation_A(domain, record, suffix) {
+    const records = Array.isArray(record) ? record : [record];
+
     return [
-        A(domain, record),
+        records.map(function (el) { return A(domain, el); }),
         CNAME("www." + domain, suffix ? domain + '.' + suffix + '.' : domain)
     ];
 }

--- a/domains/functions/delegation.js
+++ b/domains/functions/delegation.js
@@ -1,5 +1,5 @@
 function Delegation_A(domain, record, suffix) {
-    const records = Array.isArray(record) ? record : [record];
+    var records = Array.isArray(record) ? record : [record];
 
     return [
         records.map(function (el) { return A(domain, el); }),

--- a/domains/zhp.pl.d/lubuska.js
+++ b/domains/zhp.pl.d/lubuska.js
@@ -13,7 +13,8 @@ D_EXTEND('zhp.pl',
     Ms365_Subdomain('miedzyrzecz','zhp.pl'),
 
     //Delegacja domeny hufca Nowa Sól
-    Delegation_CNAME('nowasol', 'ghs.google.com.'),
+    Delegation_A('nowasol', ['216.239.32.21', '216.239.34.21', '216.239.36.21', '216.239.38.21']), // W oparciu o https://support.google.com/blogger/answer/1233387?hl=en
+    Ms365_Subdomain('nowasol','zhp.pl'), // MS365-35854
 
     // Delegacja domeny hufca Słubice
     Delegation_NS('slubice', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
@@ -21,9 +22,8 @@ D_EXTEND('zhp.pl',
     //Delegacja domeny hufca Strzelce (zmienili nazwę na hufiec Strzelecko-Drezdenecki)
     Ms365_Subdomain('strzelce','zhp.pl'),
     Delegation_A('strzelce','185.135.90.126'),
-    Ms365_Subdomain('hsd','zhp.pl'), // Rekordy potrzebne do dodania nowej domeny do offica
-    Delegation_A('hsd','185.135.90.126'), // delegacja nowej domeny
-    // Delegacja domeny hufca Sulęcin 
+
+    // Delegacja domeny hufca Sulęcin
     Ms365_Subdomain('sulecin','zhp.pl'),
 
     //Delegacja domeny hufca Szprotawa


### PR DESCRIPTION
Domena `nowasol` używa obecnie CNAME, aby podpiąć stronę z blogger.com.

Dodałem wsparcie dla wielu wpisów A i przepisałem domenę na delegację A zgodnie z https://support.google.com/blogger/answer/1233387?hl=en. To pozwoli mi dodać ich do MS365