### PR TITLE
Przeniesienie Powiatu Wloclawskiego

### DIFF
--- a/domains/zhp.pl.d/kp.js
+++ b/domains/zhp.pl.d/kp.js
@@ -22,6 +22,7 @@ D_EXTEND('zhp.pl',
     Delegation_A('koronowo', '185.255.40.51'),
     Delegation_A('nml', '185.255.40.51'),
     Delegation_A('paluki', '185.255.40.51'),
+    Delegation_A('powiatwloclawek', '185.255.40.51'),    
     Delegation_A('swiecie', '185.255.40.51'),
     Delegation_A('tuchola', '185.255.40.51'),
     Delegation_A('wloclawek', '185.255.40.51'),
@@ -40,6 +41,7 @@ D_EXTEND('zhp.pl',
     Ms365_Subdomain('naklo','zhp.pl'),
     Ms365_Subdomain('nml','zhp.pl'),
     Ms365_Subdomain('paluki','zhp.pl'),
+    Ms365_Subdomain('powiatwloclawek','zhp.pl'),   
     Ms365_Subdomain('rypin','zhp.pl'),
     Ms365_Subdomain('swiecie','zhp.pl'),
     Ms365_Subdomain('tuchola','zhp.pl'),
@@ -47,10 +49,6 @@ D_EXTEND('zhp.pl',
 
     // Hufiec Toruń (hosting hufca)
     Delegation_NS('torun', ['ns1.atthost.pl.', 'ns2.atthost.pl.']),
-
-    // Hufiec Powiatu Włocławskiego (hosting hufca)
-    Delegation_NS('powiatwloclawek', ['ns3.biznes-host.pl.', 'ns4.biznes-host.pl.']),
-    CNAME('wloclawekpowiat', 'powiatwloclawek.zhp.pl.'),
 
     // Imprezy Ogólnopolskie
     Delegation_NS('kopernikanski', ['ns1.atthost.pl.', 'ns2.atthost.pl.'])


### PR DESCRIPTION
Hufiec Powiatu Wloclawskiego zmienia hosting na hosting choragwi, zmiana delegacji NS na A, dodatkowo delegacja domeny do MS365.