### PR TITLE
add cname for csz-sfh-app

### DIFF
--- a/domains/zhp.pl.d/wydzial-it.js
+++ b/domains/zhp.pl.d/wydzial-it.js
@@ -46,7 +46,7 @@ D_EXTEND('zhp.pl',
     CNAME('konta-sfh', 'konta-sfh.pages.dev.'),
 
     // Azure Static Web Apps
-    CNAME('sfh', 'nice-island-0dd931303.5.azurestaticapps.net'),
+    CNAME('sfh', 'nice-island-0dd931303.5.azurestaticapps.net.'),
 
     // Maile z monitoringu
     TXT('monitoring', "v=spf1 ip4:213.189.38.143 -all"),

--- a/domains/zhp.pl.d/wydzial-it.js
+++ b/domains/zhp.pl.d/wydzial-it.js
@@ -45,6 +45,9 @@ D_EXTEND('zhp.pl',
     // CloudFlare Pages
     CNAME('konta-sfh', 'konta-sfh.pages.dev.'),
 
+    // Azure Static Web Apps
+    CNAME('sfh', 'nice-island-0dd931303.5.azurestaticapps.net'),
+
     // Maile z monitoringu
     TXT('monitoring', "v=spf1 ip4:213.189.38.143 -all"),
     DMARC('reject', 'reject', 'monitoring'), // strict DMARC - only this server


### PR DESCRIPTION
Dodałem CNAME do wersji produkcyjnej aplikacji statycznej csz-sfh-app, czyli do Centralnego Systemu Zgłoszeń Safe From Harm.