### PR TITLE
add cname for dev-sfh.zhp.pl

### DIFF
--- a/domains/zhp.pl.d/wydzial-it.js
+++ b/domains/zhp.pl.d/wydzial-it.js
@@ -47,6 +47,7 @@ D_EXTEND('zhp.pl',
 
     // Azure Static Web Apps
     CNAME('sfh', 'nice-island-0dd931303.5.azurestaticapps.net.'),
+    CNAME('dev-sfh', 'icy-smoke-0baadd803.5.azurestaticapps.net.'),
 
     // Maile z monitoringu
     TXT('monitoring', "v=spf1 ip4:213.189.38.143 -all"),


### PR DESCRIPTION
CNAME dla dev-sfh.zhp.pl, na której są buildy aplikacji z brancha development